### PR TITLE
Fix creating an invoice in active_admin

### DIFF
--- a/app/admin/invoices.rb
+++ b/app/admin/invoices.rb
@@ -2,5 +2,5 @@ ActiveAdmin.register Invoice do
   menu priority: 2
 
   # permit_params :batch, :number, :sales_rep_code, :invoiced_on, :paid_on, :amount, :cost
-  # permit_params :customer_id, :customer_name, :cases, :delivered
+  # permit_params :customer_code, :customer_name, :cases, :delivered
 end

--- a/app/admin/invoices.rb
+++ b/app/admin/invoices.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register Invoice do
   menu priority: 2
 
-  # permit_params :batch, :number, :sales_rep_code, :invoiced_on, :paid_on, :amount, :cost
-  # permit_params :customer_code, :customer_name, :cases, :delivered
+  permit_params :batch, :number, :sales_rep_code, :invoiced_on, :paid_on, :amount, :cost,
+                :customer_code, :customer_name, :cases, :delivered
 end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -5,11 +5,16 @@
 #  id                     :bigint           not null, primary key
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
-#  reset_password_token   :string
-#  reset_password_sent_at :datetime
 #  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_admin_users_on_email                 (email) UNIQUE
+#  index_admin_users_on_reset_password_token  (reset_password_token) UNIQUE
 #
 
 # A user that can log into the admin interface.

--- a/app/models/fake_invoice.rb
+++ b/app/models/fake_invoice.rb
@@ -57,7 +57,7 @@ class FakeInvoice < Invoice
       invoiced_on: invoiced_on,
       paid_on: Faker::Date.between(from: invoiced_on, to: Date.today),
       customer_name: customer_name,
-      customer_id: customer_name.gsub(" ", "").upcase.first(6),
+      customer_code: customer_name.gsub(" ", "").upcase.first(6),
       cost: cost,
       amount: Faker::Number.between(from: cost, to: cost * 1.25)
     )

--- a/app/models/fake_invoice.rb
+++ b/app/models/fake_invoice.rb
@@ -3,19 +3,25 @@
 # Table name: invoices
 #
 #  id             :bigint           not null, primary key
-#  batch          :string
-#  number         :string
-#  sales_rep_code :string
-#  invoiced_on    :date
-#  paid_on        :date
 #  amount         :decimal(8, 2)
-#  cost           :decimal(8, 2)
-#  customer_id    :string
-#  customer_name  :string
+#  batch          :string
 #  cases          :integer
+#  cost           :decimal(8, 2)
+#  customer_code  :string
+#  customer_name  :string
 #  delivered      :boolean
+#  invoiced_on    :date
+#  number         :string
+#  paid_on        :date
+#  sales_rep_code :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#
+# Indexes
+#
+#  index_invoices_on_batch                     (batch)
+#  index_invoices_on_batch_and_sales_rep_code  (batch,sales_rep_code)
+#  index_invoices_on_sales_rep_code            (sales_rep_code)
 #
 
 # Convenience class for generating a Invoice with fake information.

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -3,19 +3,25 @@
 # Table name: invoices
 #
 #  id             :bigint           not null, primary key
-#  batch          :string
-#  number         :string
-#  sales_rep_code :string
-#  invoiced_on    :date
-#  paid_on        :date
 #  amount         :decimal(8, 2)
-#  cost           :decimal(8, 2)
-#  customer_id    :string
-#  customer_name  :string
+#  batch          :string
 #  cases          :integer
+#  cost           :decimal(8, 2)
+#  customer_code  :string
+#  customer_name  :string
 #  delivered      :boolean
+#  invoiced_on    :date
+#  number         :string
+#  paid_on        :date
+#  sales_rep_code :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#
+# Indexes
+#
+#  index_invoices_on_batch                     (batch)
+#  index_invoices_on_batch_and_sales_rep_code  (batch,sales_rep_code)
+#  index_invoices_on_sales_rep_code            (sales_rep_code)
 #
 
 # Header for an invoice.

--- a/app/models/sales_rep.rb
+++ b/app/models/sales_rep.rb
@@ -4,24 +4,8 @@
 #
 #  id         :bigint           not null, primary key
 #  code       :string
-#  name       :string
-#  quota_type :string
-#  period1    :decimal(8, 2)
-#  period2    :decimal(8, 2)
-#  period3    :decimal(8, 2)
-#  period4    :decimal(8, 2)
-#  period5    :decimal(8, 2)
-#  goal1      :decimal(8, 2)
-#  goal2      :decimal(8, 2)
-#  goal3      :decimal(8, 2)
-#  goal4      :decimal(8, 2)
-#  goal5      :decimal(8, 2)
-#  goal6      :decimal(8, 2)
-#  goal7      :decimal(8, 2)
-#  goal8      :decimal(8, 2)
-#  goal9      :decimal(8, 2)
-#  goal10     :decimal(8, 2)
 #  comm1      :decimal(8, 2)
+#  comm10     :decimal(8, 2)
 #  comm2      :decimal(8, 2)
 #  comm3      :decimal(8, 2)
 #  comm4      :decimal(8, 2)
@@ -30,10 +14,30 @@
 #  comm7      :decimal(8, 2)
 #  comm8      :decimal(8, 2)
 #  comm9      :decimal(8, 2)
-#  comm10     :decimal(8, 2)
+#  disabled   :boolean          default(FALSE), not null
+#  goal1      :decimal(8, 2)
+#  goal10     :decimal(8, 2)
+#  goal2      :decimal(8, 2)
+#  goal3      :decimal(8, 2)
+#  goal4      :decimal(8, 2)
+#  goal5      :decimal(8, 2)
+#  goal6      :decimal(8, 2)
+#  goal7      :decimal(8, 2)
+#  goal8      :decimal(8, 2)
+#  goal9      :decimal(8, 2)
+#  name       :string
+#  period1    :decimal(8, 2)
+#  period2    :decimal(8, 2)
+#  period3    :decimal(8, 2)
+#  period4    :decimal(8, 2)
+#  period5    :decimal(8, 2)
+#  quota_type :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  disabled   :boolean          default(FALSE), not null
+#
+# Indexes
+#
+#  index_sales_reps_on_disabled  (disabled)
 #
 
 # Info for a sales rep, including commission levels.

--- a/app/presenters/reports_show_presenter.rb
+++ b/app/presenters/reports_show_presenter.rb
@@ -102,7 +102,7 @@ class ReportsShowPresenter
     margin_pct = "%.2f" % inv.margin_pct.to_f
     amount = "%.2f" % commission.amount.to_f
 
-    fields = [inv.number, inv.customer_id, inv.customer_name]
+    fields = [inv.number, inv.customer_code, inv.customer_name]
     fields += [inv.invoiced_on, inv.paid_on, inv.age_category]
     fields += [inv.amount, inv.cost, margin_pct, inv.cases, delivered]
     fields += [rep.code, rep.name, rep.quota_type, amount]

--- a/app/services/upload_invoices_csv.rb
+++ b/app/services/upload_invoices_csv.rb
@@ -10,7 +10,7 @@ class UploadInvoicesCSV
     sales_rep_code: "SLSREPNO",
     amount: "NETSALES",
     cost: "NETCOST",
-    customer_id: "CUSTNO",
+    customer_code: "CUSTNO",
     customer_name: "CUSTNAME",
     cases: "QRYSHIPPED"
   }.freeze

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -28,7 +28,7 @@ hr
           - inv = comm.invoice
           tr
             td = inv.number
-            td = inv.customer_id
+            td = inv.customer_code
             td = inv.customer_name
             td.ralign = inv.amount
             td.ralign = inv.cost

--- a/db/migrate/20200301181141_rename_customer_id_to_customer_code.rb
+++ b/db/migrate/20200301181141_rename_customer_id_to_customer_code.rb
@@ -1,0 +1,5 @@
+class RenameCustomerIdToCustomerCode < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :invoices, :customer_id, :customer_code
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_17_053509) do
+ActiveRecord::Schema.define(version: 2020_03_01_181141) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 2020_02_17_053509) do
     t.date "paid_on"
     t.decimal "amount", precision: 8, scale: 2
     t.decimal "cost", precision: 8, scale: 2
-    t.string "customer_id"
+    t.string "customer_code"
     t.string "customer_name"
     t.integer "cases"
     t.boolean "delivered"


### PR DESCRIPTION
Creating an invoice in active admin works now.

* renames `invoices.customer_id` to `invoices.customer_code`
* fixes a bug in my use of `permit_params` (they don't add; a later one replaces the earlier one)

Notes:

Ending with `_id` confuses active_admin into thinking the value was a foreign key, so the edit form had a useless dropdown.

I don't ever intend for it to be a foreign key, so it just seems better to name it `customer_code`.