### PR TITLE
Update existing invoices during CSV import

### DIFF
--- a/app/models/fake_invoice.rb
+++ b/app/models/fake_invoice.rb
@@ -21,6 +21,7 @@
 #
 #  index_invoices_on_batch                     (batch)
 #  index_invoices_on_batch_and_sales_rep_code  (batch,sales_rep_code)
+#  index_invoices_on_number                    (number)
 #  index_invoices_on_sales_rep_code            (sales_rep_code)
 #
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -39,7 +39,7 @@ class Invoice < ApplicationRecord
 
   scope :latest_batch, -> { where(batch: latest_batch_number) }
 
-  before_validation { sales_rep_code.upcase! }
+  before_validation { sales_rep_code&.upcase! }
 
   def self.latest_batch_number
     Invoice.order(created_at: :desc).limit(1).pluck(:batch).first

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -21,6 +21,7 @@
 #
 #  index_invoices_on_batch                     (batch)
 #  index_invoices_on_batch_and_sales_rep_code  (batch,sales_rep_code)
+#  index_invoices_on_number                    (number)
 #  index_invoices_on_sales_rep_code            (sales_rep_code)
 #
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -28,7 +28,7 @@
 # Header for an invoice.
 class Invoice < ApplicationRecord
   validates :batch, presence: true
-  validates :number, presence: true
+  validates :number, presence: true, uniqueness: true
   validates :sales_rep_code, presence: true
   validates :invoiced_on, presence: true
   validates :paid_on, presence: true

--- a/app/services/upload_invoices_csv.rb
+++ b/app/services/upload_invoices_csv.rb
@@ -20,8 +20,9 @@ class UploadInvoicesCSV
     @result = nil
     @file = file
     @csv = CSV.read(@file, headers: true)
+    validate_headers
+
     @batch_number = Invoice.next_batch_number + "-csv"
-    validate
   end
 
   def run
@@ -80,7 +81,7 @@ class UploadInvoicesCSV
 
   private
 
-  def validate
+  def validate_headers
     return if HEADERS.to_set.subset?(csv.headers.to_set)
 
     errors << "invalid headers (expecting #{HEADERS.join(', ')})"

--- a/app/services/upload_invoices_csv.rb
+++ b/app/services/upload_invoices_csv.rb
@@ -35,16 +35,16 @@ class UploadInvoicesCSV
         row_num = idx + 2
         inv = invoice_for_row(row)
         if inv.invalid?
-          errors << "invalid data in csv row #{row_num}"
+          errors << "invalid data in row #{row_num}: #{inv.errors.full_messages.join(',')}"
         # elsif inv.amount.negative?
-        #   errors << "negative sales $ in csv row #{row_num}"
+        #   errors << "negative sales $ in row #{row_num}"
         # elsif inv.amount.zero?
-        #   errors << "zero sales $ in csv row #{row_num}"
+        #   errors << "zero sales $ in row #{row_num}"
         else
           arr << inv
         end
-      rescue
-        errors << "invalid data in csv row #{row_num}"
+      rescue StandardError => err
+        errors << "invalid data in row #{row_num}: #{err}"
       end
     end
 
@@ -83,6 +83,6 @@ class UploadInvoicesCSV
   def validate
     return if HEADERS.to_set.subset?(csv.headers.to_set)
 
-    errors << ["invalid headers"]
+    errors << "invalid headers"
   end
 end

--- a/app/services/upload_invoices_csv.rb
+++ b/app/services/upload_invoices_csv.rb
@@ -83,6 +83,6 @@ class UploadInvoicesCSV
   def validate
     return if HEADERS.to_set.subset?(csv.headers.to_set)
 
-    errors << "invalid headers"
+    errors << "invalid headers (expecting #{HEADERS.join(', ')})"
   end
 end

--- a/app/views/batches/upload_fail.html.slim
+++ b/app/views/batches/upload_fail.html.slim
@@ -1,9 +1,9 @@
 main.container[role="main"]
   .jumbotron
-    h2 CSV import failed.
+    h2.text-danger CSV import failed.
     hr
     p Errors:
     ul
       - errors.each do |err|
         li = err
-    a.btn.btn-primary.mt-5 href=reports_path Return to Dashboard
+    a.btn.btn-primary.mt-3 href=reports_path Return to Dashboard

--- a/app/views/batches/upload_fail.html.slim
+++ b/app/views/batches/upload_fail.html.slim
@@ -6,3 +6,4 @@ main.container[role="main"]
     ul
       - errors.each do |err|
         li = err
+    a.btn.btn-primary.mt-5 href=reports_path Return to Dashboard

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -55,6 +55,9 @@ main.container.w-75[role="main"]
   .card.bg-light.mb-4
     .card-header.h5.font-weight-bold Upload CSV
     .card-body
+      strong Required Headers:
+      p
+        small = UploadInvoicesCSV::HEADERS.join(", ")
       = form_with(url: upload_batches_path, method: "post", local: true, multipart: true) do
         = file_field_tag "invoices", accept: "text/csv", class: "form-control-file"
         hr

--- a/db/migrate/20200302004410_add_index_on_invoice_numbers.rb
+++ b/db/migrate/20200302004410_add_index_on_invoice_numbers.rb
@@ -1,0 +1,5 @@
+class AddIndexOnInvoiceNumbers < ActiveRecord::Migration[6.0]
+  def change
+    add_index :invoices, :number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_01_181141) do
+ActiveRecord::Schema.define(version: 2020_03_02_004410) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2020_03_01_181141) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["batch", "sales_rep_code"], name: "index_invoices_on_batch_and_sales_rep_code"
     t.index ["batch"], name: "index_invoices_on_batch"
+    t.index ["number"], name: "index_invoices_on_number"
     t.index ["sales_rep_code"], name: "index_invoices_on_sales_rep_code"
   end
 


### PR DESCRIPTION
This will prevent duplicate invoices from being created.

It does mean that they get pulled out of a batch, but we're probably not going to use the batch numbers for anything.

Also:

-  fixes an issue where an empty invoice couldn't be validated because it would call cause `nil.upcase!` to be called
- shows more info (full active_record error messages) for failed rows during a csv import