### PR TITLE
New Logic, Part 3

### DIFF
--- a/app/models/commission.rb
+++ b/app/models/commission.rb
@@ -24,8 +24,8 @@ class Commission
     r = sales_rep
 
     [
-      i.number, i.customer_code, i.customer.name, i.order_date,
-      paid_date, age_category, i.amount, paid_amount, i.cost,
+      i.number, i.customer_code, i.customer.name, order_date,
+      paid_date, age_category, i.amount, paid_amount, pretty_num(i.cost),
       pretty_num(adjusted_cost), pretty_num(paid_fraction),
       pretty_num(i.margin_pct), i.qty_ord,
       r.code, r.name, r.quota_type, pretty_num(amount)

--- a/app/models/commission.rb
+++ b/app/models/commission.rb
@@ -53,10 +53,11 @@ class Commission
     base_pct * (age_adjustment_pct / 100)
   end
 
-  # Returns the total amount that the customer paid towards the invoice,
-  # which may be lower than the original invoice amount.
+  # The dollar amount used as a base for calculating commission. This is typically
+  # the same as real_paid_amount.
   def paid_amount
-    # some alpha invoices have payments split between both systems.
+    # For alpha invoices, because some were paid across both systems, if real_paid_amount
+    # is lower, we just trust the invoice header sales total.
     if invoice.source == :alpha && real_paid_amount < invoice.amount
       return invoice.amount
     end
@@ -68,6 +69,7 @@ class Commission
     [real_paid_amount, invoice.amount].min
   end
 
+  # The total amount a customer paid that was put towards the invoice in Retalix.
   def real_paid_amount
     purged_records.select { |pr| pr.invoice_type == 2 }.map(&:amount).sum
   end

--- a/app/models/invoice_header.rb
+++ b/app/models/invoice_header.rb
@@ -58,4 +58,8 @@ class InvoiceHeader < ApplicationRecord
   def margin_pct
     100 * margin
   end
+
+  def source
+    number.to_i < 790000 ? :alpha : :retalix
+  end
 end

--- a/app/presenters/reports_show_presenter.rb
+++ b/app/presenters/reports_show_presenter.rb
@@ -37,7 +37,7 @@ class ReportsShowPresenter
   end
 
   def grand_total
-    totals_by_enabled_rep.values.reduce(:+) || 0
+    totals_by_enabled_rep.values.sum
   end
 
   def disabled_reps
@@ -73,7 +73,7 @@ class ReportsShowPresenter
 
   def totals_by_enabled_rep
     commissions_by_enabled_rep.transform_values do |comms|
-      comms.map(&:amount).reduce(:+)
+      comms.map(&:amount).sum
     end
   end
   memoize :totals_by_enabled_rep

--- a/app/views/reports/_table.html.slim
+++ b/app/views/reports/_table.html.slim
@@ -27,5 +27,5 @@ table.blueBar
         td.text-right = number_to_currency(comm.amount, unit: "")
 
 .blueBarTotal
-  - total = commissions.map(&:amount).reduce(:+)
+  - total = commissions.map(&:amount).sum
   = "Total Commission: $#{number_to_currency(total, unit: '')}"

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -8,6 +8,11 @@ main.container role="main"
     h2.mb-4 Welcome to Commission Reporter!
     p Choose a report below, or upload a CSV containing invoice headers.
 
+  ruby:
+    today = Date.today
+    saturday = today - (today.wday + 1) % 7
+    sunday = saturday - 6
+
   .card.bg-light.mb-4
     .card-header.h5.font-weight-bold
       a href="#id-dateCard" data-toggle="collapse" Get Report By Date
@@ -16,10 +21,10 @@ main.container role="main"
         .form-row
           .form-group.col-md-6
             = label_tag "start_date", "Start Date", for: "startDate"
-            = date_field_tag "from", Date.today - 1.week, class: "form-control", id: "startDate", required: true
+            = date_field_tag "from", sunday, class: "form-control", id: "startDate", required: true
           .form-group.col-md-6
             = label_tag "end_date", "End Date", for: "endDate"
-            = date_field_tag "to", Date.today, class: "form-control", id: "endDate", required: true
+            = date_field_tag "to", saturday, class: "form-control", id: "endDate", required: true
         .form-group
           = label_tag "format", "Format", for: "id-format"
           = select_tag "format",

--- a/scripts/import_purged_records.rb
+++ b/scripts/import_purged_records.rb
@@ -13,6 +13,9 @@ def import(file_name)
   puts svc.result
 end
 
+puts "deleting purged a/r records..."
+PurgedRecord.delete_all
+
 print_counts(PurgedRecord) do
   import("../data/rrwrecwp.csv")
 end


### PR DESCRIPTION
Fixes some bugs that were largely causing too much commission to be suggested.


- when querying purged records, a matching invoice number should beat date filtering
- use invoice header sales total when:
  - invoice is from alpha
  - total payment is less than invoice total
  - (this is because some invoices were partially paid in alpha)
- use `sum` instead of `reduce(:+)`

This should also include https://github.com/napolif/commission-reporter/commit/a107e7dead5215a6c6dfb2c77a62d5a06dce0d9c and https://github.com/napolif/commission-reporter/commit/4f89a9bd38571188e21dcc69f8118500d7cf92b5, which were already merged into master.

- change which retalix invoice header fields to import
- `paid_amount` should never be higher than `invoice.amount`

### Notes:

`Commission` now has `#paid_amount` and `#real_paid_amount`.

- **real_paid_amount**: The total amount a customer paid that was put towards the invoice in Retalix.
- **paid_amount**: The dollar amount used as a base for calculating commission.  Typically the same as `real_paid_amount`, but is subject to a few constraints.